### PR TITLE
Let local gateways have a carrier, and use it when routing

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -332,7 +332,7 @@ class Application < ActiveRecord::Base
     # that have that carrier. If there's no such channel, keep them all.
     if carrier = msg.carrier
       carriers = Array(carrier)
-      matching_channels = channels.select { |chan| carriers.include?(chan.carrier_guid) }
+      matching_channels = channels.select { |chan| chan.matches_carrier_guids?(carriers) }
       channels = matching_channels unless matching_channels.empty?
     end
 

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -328,6 +328,14 @@ class Application < ActiveRecord::Base
     # Filter them according to custom attributes
     channels = channels.select{|x| x.can_route_ao? msg}
 
+    # If the message has an associated carrier, try to keep channels
+    # that have that carrier. If there's no such channel, keep them all.
+    if carrier = msg.carrier
+      carriers = Array(carrier)
+      matching_channels = channels.select { |chan| carriers.include?(chan.carrier_guid) }
+      channels = matching_channels unless matching_channels.empty?
+    end
+
     channels.sort!{|x, y| (x.priority || 100) <=> (y.priority || 100)}
 
     if channels.empty?

--- a/app/models/carrier.rb
+++ b/app/models/carrier.rb
@@ -71,6 +71,52 @@ class Carrier < ActiveRecord::Base
     @@carriers = nil
   end
 
+  # Returns [countries, carriers]
+  def self.infer_from_phone_number(number, country_iso = nil, carrier_iso = nil)
+    countries = []
+    carriers = []
+
+    # Infer country from phone number
+    unless country_iso
+      countries = Country.all.select{|x| number.start_with? x.phone_prefix}
+      if countries.length > 0
+        # Slipt countries with and without area codes
+        with_area_codes, without_area_codes = countries.partition{|x| x.area_codes.present?}
+        # From those with area codes, select only the ones for which the number start with them
+        with_area_codes = with_area_codes.select{|x| x.area_codes.split(',').any?{|y| number.start_with?(x.phone_prefix + y.strip)}}
+        # If we find matches with area codes, use them. Otherwise, use those without area codes
+        countries = with_area_codes.present? ? with_area_codes : without_area_codes
+
+        if countries.length == 1
+          country_iso = countries[0].iso2
+        else
+          country_iso = countries.map(&:iso2)
+        end
+      end
+    end
+
+    # Infer carrier from phone number (if country is present)
+    if country_iso && !carrier_iso
+      carrier_countries = country_iso
+      carrier_countries = [carrier_countries] unless carrier_countries.kind_of? Array
+      carrier_countries = carrier_countries.map{|x| Country.find_by_iso2_or_iso3 x}
+
+      carrier_countries.each do |c|
+        next unless c
+        cs = Carrier.find_by_country_id c.id
+        cs.each do |carrier|
+          next unless carrier.prefixes.present?
+          prefixes = carrier.prefixes.split ','
+          if prefixes.any?{|p| number.start_with?(c.phone_prefix + p.strip)}
+            carriers << carrier
+          end
+        end
+      end
+    end
+
+    [countries, carriers]
+  end
+
   private
 
   def clear_cache

--- a/app/models/messages/message_custom_attributes.rb
+++ b/app/models/messages/message_custom_attributes.rb
@@ -41,51 +41,27 @@ module MessageCustomAttributes
 
     number = address.mobile_number
 
-    # Infer country from phone number
-    unless self.country
-      countries = Country.all.select{|x| number.start_with? x.phone_prefix}
-      if countries.length > 0
-        # Slipt countries with and without area codes
-        with_area_codes, without_area_codes = countries.partition{|x| x.area_codes.present?}
-        # From those with area codes, select only the ones for which the number start with them
-        with_area_codes = with_area_codes.select{|x| x.area_codes.split(',').any?{|y| number.start_with?(x.phone_prefix + y.strip)}}
-        # If we find matches with area codes, use them. Otherwise, use those without area codes
-        countries = with_area_codes.present? ? with_area_codes : without_area_codes
+    # Infer country and carrier from phone number
+    countries, carriers = Carrier.infer_from_phone_number(number, self.country, self.carrier)
 
-        if countries.length == 1
-          ThreadLocalLogger << "Country #{countries[0].name} (#{countries[0].iso2}) was inferred from prefix"
-          self.country = countries[0].iso2
-        else
-          self.country = countries.map do |c|
-            ThreadLocalLogger << "Country #{c.name} (#{c.iso2}) was inferred from prefix"
-            c.iso2
-          end
+    unless countries.empty?
+      if countries.length == 1
+        ThreadLocalLogger << "Country #{countries[0].name} (#{countries[0].iso2}) was inferred from prefix"
+        self.country = countries[0].iso2
+      else
+        self.country = countries.map do |c|
+          ThreadLocalLogger << "Country #{c.name} (#{c.iso2}) was inferred from prefix"
+          c.iso2
         end
       end
     end
 
-    # Infer carrier from phone number (if country is present)
-    if self.country and not self.carrier
-      countries = self.country
-      countries = [countries] unless countries.kind_of? Array
-      countries = countries.map{|x| Country.find_by_iso2_or_iso3 x}
-
-      carriers = []
-
-      countries.each do |c|
-        next unless c
-        cs = Carrier.find_by_country_id c.id
-        cs.each do |carrier|
-          next unless carrier.prefixes.present?
-          prefixes = carrier.prefixes.split ','
-          if prefixes.any?{|p| number.start_with?(c.phone_prefix + p.strip)}
-            ThreadLocalLogger << "Carrier #{carrier.name} was inferred from prefix"
-            carriers << carrier
-          end
-        end
+    unless carriers.empty?
+      carriers.each do |carrier|
+        ThreadLocalLogger << "Carrier #{carrier.name} was inferred from prefix"
       end
 
-      self.carrier = carriers.length == 1 ? carriers[0].guid : carriers.map(&:guid) unless carriers.empty?
+      self.carrier = carriers.length == 1 ? carriers[0].guid : carriers.map(&:guid)
     end
 
     # Infer country and carrier from stored MobileNumber, if any

--- a/app/models/qst/server/qst_server_channel.rb
+++ b/app/models/qst/server/qst_server_channel.rb
@@ -66,6 +66,13 @@ class QstServerChannel < Channel
     true
   end
 
+  def matches_carrier_guids?(carrier_guids)
+    return false unless self.carrier_guid
+
+    self_carrier_guids = self.carrier_guid.split(",")
+    self_carrier_guids.any? { |self_carrier_guid| carrier_guids.include?(self_carrier_guid) }
+  end
+
   private
 
   def hash_password
@@ -123,7 +130,7 @@ class QstServerChannel < Channel
     if address.present?
       countries, carriers = Carrier.infer_from_phone_number(address.mobile_number)
       unless carriers.empty?
-        self.carrier_guid = carriers.first.guid
+        self.carrier_guid = carriers.map(&:guid).join(",")
       end
     else
       self.carrier_guid = nil

--- a/app/models/qst/server/qst_server_channel.rb
+++ b/app/models/qst/server/qst_server_channel.rb
@@ -35,6 +35,8 @@ class QstServerChannel < Channel
   before_save :ticket_record_password, :if => lambda { ticket_code.present? }
   after_save :ticket_mark_as_complete, :if => lambda { ticket_code.present? }
 
+  before_save :infer_carrier
+
   def self.title
     "QST server (local gateway)"
   end
@@ -115,5 +117,17 @@ class QstServerChannel < Channel
       attributes[sym] = value if value.present?
     end
     attributes
+  end
+
+  def infer_carrier
+    if address.present?
+      countries, carriers = Carrier.infer_from_phone_number(address.mobile_number)
+      unless carriers.empty?
+        self.carrier_guid = carriers.first.guid
+      end
+    else
+      self.carrier_guid = nil
+    end
+    true
   end
 end

--- a/db/migrate/20160706151602_add_carrier_guid_to_channels.rb
+++ b/db/migrate/20160706151602_add_carrier_guid_to_channels.rb
@@ -1,0 +1,5 @@
+class AddCarrierGuidToChannels < ActiveRecord::Migration
+  def change
+    add_column :channels, :carrier_guid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160311152059) do
+ActiveRecord::Schema.define(:version => 20160706151602) do
 
   create_table "accounts", :force => true do |t|
     t.string   "name"
@@ -142,6 +142,7 @@ ActiveRecord::Schema.define(:version => 20160311152059) do
     t.decimal  "ao_cost",          :precision => 10, :scale => 2
     t.decimal  "at_cost",          :precision => 10, :scale => 2
     t.datetime "last_activity_at"
+    t.string   "carrier_guid"
   end
 
   add_index "channels", ["account_id", "name"], :name => "index_channels_on_account_id_and_name"

--- a/test/unit/application_test.rb
+++ b/test/unit/application_test.rb
@@ -596,6 +596,21 @@ class ApplicationTest < ActiveSupport::TestCase
     assert_equal 1.2, msg.cost
   end
 
+  test "route ao prefer channel with matching carrier" do
+    app = Application.make
+    carrier = Carrier.make :prefixes => "99"
+    chan1 = QstServerChannel.make :account_id => app.account_id, :priority => 0, :address => "12"
+    chan2 = QstServerChannel.make :account_id => app.account_id, :priority => 100, :carrier_guid => carrier.guid
+
+    address = "#{carrier.country.phone_prefix}#{carrier.prefixes}987654321"
+    msg = app.account.ao_messages.make_unsaved :to => "sms://#{address}"
+    app.route_ao msg, 'test'
+
+    msg.reload
+
+    assert_equal chan2.id, msg.channel_id
+  end
+
   test "should not create if password is blank" do
     app = Application.make_unsaved
     app.password = app.password_confirmation = ''

--- a/test/unit/qst_server_channel_test.rb
+++ b/test/unit/qst_server_channel_test.rb
@@ -66,4 +66,17 @@ class QstServerChannelTest < ActiveSupport::TestCase
     @chan.use_ticket = true
     assert_false @chan.valid?
   end
+
+  test "should add carrier if matches number" do
+    carrier = Carrier.make
+    address = "#{carrier.country.phone_prefix}#{carrier.prefixes}987654321"
+    chan = QstServerChannel.make :address => address, :configuration => {:password => 'foo', :password_confirmation => 'foo'}
+    assert_equal carrier.guid, chan.carrier_guid
+  end
+
+  test "should not add carrier if doesn't match number" do
+    carrier = Carrier.make
+    chan = QstServerChannel.make :address => "1234", :configuration => {:password => 'foo', :password_confirmation => 'foo'}
+    assert_equal nil, chan.carrier_guid
+  end
 end

--- a/test/unit/qst_server_channel_test.rb
+++ b/test/unit/qst_server_channel_test.rb
@@ -74,6 +74,15 @@ class QstServerChannelTest < ActiveSupport::TestCase
     assert_equal carrier.guid, chan.carrier_guid
   end
 
+  test "should add carrier if matches number (multiple)" do
+    carrier = Carrier.make
+    country = Country.make :phone_prefix => "98"
+    carrier1 = country.carriers.make :prefixes => "12"
+    carrier2 = country.carriers.make :prefixes => "1"
+    chan = QstServerChannel.make :address => "9812", :configuration => {:password => 'foo', :password_confirmation => 'foo'}
+    assert_equal [carrier1.guid, carrier2.guid].sort, chan.carrier_guid.split(",").sort
+  end
+
   test "should not add carrier if doesn't match number" do
     carrier = Carrier.make
     chan = QstServerChannel.make :address => "1234", :configuration => {:password => 'foo', :password_confirmation => 'foo'}


### PR DESCRIPTION
Now QST server channels (local gateways) can have an associated carrier. This carrier is inferred from the local gateway's number, in a similar way to how we infer a carrier when an AO message arrives.

When routing an AO message, if we find a target carrier for the message we see if there are channels with that carrier. If so, we route to one of those channels (using the regular rules, priority, etc.)

With this, adding multiple channels in Pollit, where each message sent by Pollit should be routes to a the channel that matches a carrier given the prefix of a phone number, should automatically work from now on.