### PR TITLE
Prefer suggested channel and last channel over carrier

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -328,14 +328,7 @@ class Application < ActiveRecord::Base
     # Filter them according to custom attributes
     channels = channels.select{|x| x.can_route_ao? msg}
 
-    # If the message has an associated carrier, try to keep channels
-    # that have that carrier. If there's no such channel, keep them all.
-    if carrier = msg.carrier
-      carriers = Array(carrier)
-      matching_channels = channels.select { |chan| chan.matches_carrier_guids?(carriers) }
-      channels = matching_channels unless matching_channels.empty?
-    end
-
+    # Sort by priority
     channels.sort!{|x, y| (x.priority || 100) <=> (y.priority || 100)}
 
     if channels.empty?
@@ -360,6 +353,14 @@ class Application < ActiveRecord::Base
     if last_channel
       ThreadLocalLogger << "'#{last_channel.name}' selected from address sources"
       return [last_channel]
+    end
+
+    # If the message has an associated carrier, try to keep channels
+    # that have that carrier. If there's no such channel, keep them all.
+    if carrier = msg.carrier
+      carriers = Array(carrier)
+      matching_channels = channels.select { |chan| chan.matches_carrier_guids?(carriers) }
+      channels = matching_channels unless matching_channels.empty?
     end
 
     return channels

--- a/test/unit/application_test.rb
+++ b/test/unit/application_test.rb
@@ -695,6 +695,37 @@ class ApplicationTest < ActiveSupport::TestCase
     end
   end
 
+  test "route ao prefer suggested channel over matching carrier" do
+    app = Application.make
+    country = Country.make :phone_prefix => "98"
+    carrier = country.carriers.make :prefixes => "76"
+    chan1 = QstServerChannel.make :account_id => app.account_id, :priority => 100, :address => "12"
+    chan2 = QstServerChannel.make :account_id => app.account_id, :priority => 100, :address => "987654"
+
+    msg = app.account.ao_messages.make_unsaved :to => "sms://987612", :suggested_channel => chan1.name
+    app.route_ao msg, 'test'
+
+    msg.reload
+
+    assert_equal chan1.id, msg.channel_id
+  end
+
+  test "route ao prefer last at channel over matching carrier" do
+    app = Application.make
+    country = Country.make :phone_prefix => "98"
+    carrier = country.carriers.make :prefixes => "76"
+    chan1 = QstServerChannel.make :account_id => app.account_id, :priority => 100, :address => "12"
+    chan2 = QstServerChannel.make :account_id => app.account_id, :priority => 100, :address => "987654"
+
+    AddressSource.create! :account_id => app.account.id, :application_id => app.id, :channel_id => chan1.id, :address => "sms://987612"
+
+    msg = app.account.ao_messages.make_unsaved :to => "sms://987612"
+    app.route_ao msg, 'test'
+
+    msg.reload
+
+    assert_equal chan1.id, msg.channel_id
+  end
 
   test "should not create if password is blank" do
     app = Application.make_unsaved


### PR DESCRIPTION
If a message has a suggested channel, or there is a last AT
channel, use them before checking carrier restrictions.