### PR TITLE
Log missing 'from' address in SMPP messages

### DIFF
--- a/app/models/smpp/send_smpp_message_job.rb
+++ b/app/models/smpp/send_smpp_message_job.rb
@@ -35,6 +35,11 @@ class SendSmppMessageJob
     @account = Account.find_by_id @account_id
     @channel = @account.channels.find_by_id @channel_id
 
+    unless @msg.from
+      @msg.send_failed @account, @channel, "Message doesn't have a 'from' address"
+      return false
+    end
+
     from = @msg.from.protocol == 'sms' ? @msg.from.without_protocol : @channel.address.without_protocol
     to = @msg.to.without_protocol
     sms = @msg.subject_and_body

--- a/test/unit/send_smpp_message_job_test.rb
+++ b/test/unit/send_smpp_message_job_test.rb
@@ -59,4 +59,15 @@ class SendSmppMessageJobTest < ActiveSupport::TestCase
       {1234 => 'foo', 0x1234 => 'bar'})
     assert job.perform(delegate)
   end
+
+  test "inform when message doesn't have 'from' address" do
+    msg = AoMessage.make :account => @chan.account, :channel => @chan, :state => 'queued', :from => nil
+
+    job = SendSmppMessageJob.new msg.account_id, @chan.id, msg.id
+    job.perform nil
+
+    assert_equal msg.logs.count, 1
+    assert_true msg.logs.first.message.include? "Message doesn't have a 'from' address"
+    assert_not_equal 'delivered', msg.state
+  end
 end


### PR DESCRIPTION
It was failing with a generic warning:

```
undefined method `protocol' for nil:NilClass
```