### PR TITLE
Update Github gems to HTTPs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
+
 gem 'rails', '3.2.22.5'
 gem 'mysql2', '~> 0.3.17'
 gem "mail"
@@ -37,6 +39,7 @@ gem 'omniauth-openid'
 gem 'omniauth-google-oauth2'
 gem 'alto_guisso', github: "instedd/alto_guisso", branch: 'master'
 gem 'alto_guisso_rails', github: "instedd/alto_guisso_rails", branch: 'master'
+gem 'dalli', '2.7.9' # required by `alto_guisso_rails`, fixed to avoid auto-upgrade - but by all means update if/when needed
 gem 'slim'
 gem 'lodash-rails'
 gem 'knockoutjs-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,17 @@
 GIT
-  remote: git://github.com/instedd/alto_guisso.git
+  remote: https://bitbucket.org/instedd/pigeon.git
+  revision: 50f5268e3690071937cdcce581a29922ef723bf7
+  branch: master
+  specs:
+    instedd-pigeon (0.3.1)
+      json
+      rails (~> 3.2)
+      rest-client
+      twilio-ruby
+      twitter_oauth
+
+GIT
+  remote: https://github.com/instedd/alto_guisso
   revision: f9452bb8eb0b8a2788b3f290d5bdb4f545f89427
   branch: master
   specs:
@@ -7,7 +19,7 @@ GIT
       rack-oauth2
 
 GIT
-  remote: git://github.com/instedd/alto_guisso_rails.git
+  remote: https://github.com/instedd/alto_guisso_rails
   revision: 3324e4e85040b4db6279099309e9cb6f836ee331
   branch: master
   specs:
@@ -19,18 +31,6 @@ GIT
       rack-oauth2
       rails (>= 3.0)
       ruby-openid
-
-GIT
-  remote: https://bitbucket.org/instedd/pigeon.git
-  revision: 50f5268e3690071937cdcce581a29922ef723bf7
-  branch: master
-  specs:
-    instedd-pigeon (0.3.1)
-      json
-      rails (~> 3.2)
-      rest-client
-      twilio-ruby
-      twitter_oauth
 
 GIT
   remote: https://github.com/instedd/poirot_rails.git
@@ -361,6 +361,7 @@ DEPENDENCIES
   coffee-rails (~> 3.2.0)
   daemon_controller
   daemons
+  dalli (= 2.7.9)
   decent_exposure
   devise
   dynamic_form


### PR DESCRIPTION
The `git://` protocol was deprecated by Github.

The `dalli` gem version was fixed to prevent an unsolicited upgrade.

See https://github.blog/2021-09-01-improving-git-protocol-security-github/