### PR TITLE
Log Africa's Talking errors

### DIFF
--- a/app/models/africas_talking/AfricasTalkingGateway.rb
+++ b/app/models/africas_talking/AfricasTalkingGateway.rb
@@ -6,6 +6,10 @@ require 'uri'
 require 'json'
 
 class AfricasTalkingGatewayException < Exception
+	def initialize(statusCode = nil)
+		@statusCode = statusCode
+	end
+	attr_reader :statusCode
 end
 
 class SMSMessages
@@ -130,10 +134,10 @@ class AfricasTalkingGateway
 				return reports
 			end
 
-			raise AfricasTalkingGatewayException, messageData["Message"]
+			raise AfricasTalkingGatewayException.new(@response_code), messageData["Message"]
 
 		else
-  			raise AfricasTalkingGatewayException, response
+  			raise AfricasTalkingGatewayException.new(@response_code), response
 		end
 	 end
 

--- a/lib/services/generic_daemon.rb
+++ b/lib/services/generic_daemon.rb
@@ -16,7 +16,7 @@
 # along with Nuntium.  If not, see <http://www.gnu.org/licenses/>.
 
 def start_service(log_name)
-  $log_path = File.expand_path("../../../log/#{log_name}.log", __FILE__)
+  $log_path = STDOUT
 
   ENV["RAILS_ENV"] = ARGV[0] unless ARGV.empty?
 


### PR DESCRIPTION
This PR updates the Africa's Talking channel to mark the failed AOs with `state: failed`.

It also makes the daemons services log to STDOUT so it plays better with our Docker-based setups in Rancher.

This code is successfully running in a full-scale survey already.