### PR TITLE
Detect GeoPoll AT's to: number

### DIFF
--- a/app/controllers/geopoll_controller.rb
+++ b/app/controllers/geopoll_controller.rb
@@ -33,13 +33,13 @@ class GeopollController < ApplicationController
     end
 
     unknown_params = params.except(
-      'Identifier', 'Signature', 'SourceAddress', 'MessageText', # GeoPoll API specification
+      'Identifier', 'Signature', 'SourceAddress', 'TargetAddress', 'MessageText', # GeoPoll API specification
       'account_name', 'channel_name', 'controller', 'action' # Rails-generated parameters
     )
 
     msg = AtMessage.new
     msg.from = "sms://#{params[:SourceAddress]}"
-    msg.to   = "sms://#{channel.configuration[:from]}"
+    msg.to   = "sms://#{params[:TargetAddress]}"
     msg.body = params[:MessageText]
     msg.channel_relative_id = params[:Identifier]
     account.route_at msg, channel

--- a/app/controllers/geopoll_controller.rb
+++ b/app/controllers/geopoll_controller.rb
@@ -20,7 +20,7 @@ require 'digest/md5'
 class GeopollController < ApplicationController
   skip_filter :check_login
 
-  # POST /:account_name/:channel_name/:secret_token/geopoll/incoming
+  # POST /:account_name/:channel_name/geopoll/incoming
   def incoming
     account = Account.find_by_id_or_name(params[:account_name])
     channel = account.geopoll_channels.find_by_name(params[:channel_name])
@@ -28,7 +28,7 @@ class GeopollController < ApplicationController
     identifier = params[:Identifier]
     signature = Digest::MD5.hexdigest(auth_token + identifier)
 
-    if signature != params[:Signature]
+    if !(ActiveSupport::SecurityUtils.secure_compare params[:Signature], signature)
       return render text: "Error", status: :unauthorized
     end
 

--- a/app/views/interactions/show.html.erb
+++ b/app/views/interactions/show.html.erb
@@ -110,6 +110,18 @@
     </ul>
   <%- end -%>
 
+  <%- if channels.any?{|c| c.kind == 'geopoll'} -%>
+    <div><b>Via <%= link_to 'GeoPoll', 'https://www.geopoll.com/', :target => '_blank' -%></b></div>
+    <ul>
+      <%- channels.select{|c| c.kind == 'geopoll'}.each do |channel| -%>
+        <li>Incoming Messages URL: <span class="url">POST <%= geopoll_incoming_url(:account_name => account.name, :channel_name => channel.name) -%></span>
+          create Application Terminated Messages in channel <%= channel.name %></li>
+        <li>Delivery Reports Receiver URL: <span class="url">POST <%= geopoll_status_url(:account_name => account.name, :channel_name => channel.name) -%></span>
+          receive delivery reports in channel <%= channel.name %></li>
+      <%- end -%>
+    </ul>
+  <%- end -%>
+
   <%- unless applications.empty? -%>
     <div><b>Via <%= link_to 'RSS', 'http://en.wikipedia.org/wiki/RSS', :target => '_blank' -%></b></div>
     Use <%= link_to 'Http Basic Authentication', 'http://en.wikipedia.org/wiki/Basic_access_authentication', :target => '_blank' -%> with application credentials (use "account/application" as username).


### PR DESCRIPTION
This PR generally improves GeoPoll's integration, better handling incoming requests parameters, and detecting the `to:` field for incoming AT's (ie, the channel's own number).

Fixes #76