### PR TITLE
Fix: QstServer keeps trying to authenticate against Guisso

### DIFF
--- a/app/controllers/qst_server_controller.rb
+++ b/app/controllers/qst_server_controller.rb
@@ -16,7 +16,7 @@
 # along with Nuntium.  If not, see <http://www.gnu.org/licenses/>.
 
 class QstServerController < ApplicationController
-  skip_filter :check_login
+  skip_filter :check_login, :check_account
 
   before_filter :authenticate
   def authenticate


### PR DESCRIPTION
The QstServerController skipped calls to `check_login` (that merely delegates to `authenticate_user!`) but didn't skip the call the `check_account` that was calling `user_signed_in?` that would call Guisso's `/basic/check` using the QST channel name & password.

That didn't seem to break anything, but the call is useless and leaks Nuntium credentials to Guisso.