### PR TITLE
Add the api_ao_messages#index action

### DIFF
--- a/app/controllers/api/api_ao_messages_controller.rb
+++ b/app/controllers/api/api_ao_messages_controller.rb
@@ -5,10 +5,20 @@ class ApiAoMessagesController < ApiAuthenticatedController
   rescue_from(KeyError) { head :bad_request }
 
   def index
-    render :json => AoMessage.find_all_by_application_id_and_token(@application.id, params.fetch(:token))
+    ao_messages = AoMessage.find_all_by_application_id_and_token(@application.id, params.fetch(:token))
+    respond ao_messages
   end
 
   def create
     create_from_request
+  end
+
+  private
+
+  def respond(object)
+    respond_to do |format|
+      format.xml { render :xml => object.to_xml(:root => 'ao_messages', :skip_types => true) }
+      format.json { render :json => object }
+    end
   end
 end

--- a/app/controllers/api/api_ao_messages_controller.rb
+++ b/app/controllers/api/api_ao_messages_controller.rb
@@ -2,6 +2,12 @@ class ApiAoMessagesController < ApiAuthenticatedController
   before_filter :require_account_and_application!
   include AoMessageCreateCommon
 
+  rescue_from(KeyError) { head :bad_request }
+
+  def index
+    render :json => AoMessage.find_all_by_application_id_and_token(@application.id, params.fetch(:token))
+  end
+
   def create
     create_from_request
   end

--- a/app/controllers/api/api_ao_messages_controller.rb
+++ b/app/controllers/api/api_ao_messages_controller.rb
@@ -19,7 +19,7 @@ class ApiAoMessagesController < ApiAuthenticatedController
 
   def respond(object)
     if page = object.next_page
-      response.headers["Link"] = %(<#{api_ao_messages_url(page: page)}>; rel="next")
+      response.headers["Link"] = %(<#{api_ao_messages_url(token: params[:token], page: page)}>; rel="next")
     end
 
     respond_to do |format|

--- a/app/models/messages/message_serialization.rb
+++ b/app/models/messages/message_serialization.rb
@@ -49,6 +49,13 @@ module MessageSerialization
     hash
   end
 
+  def to_xml(options = {})
+    options[:indent] ||= 2
+    xml = options[:builder] ||= Builder::XmlMarkup.new(:indent => options[:indent])
+    xml.instruct! unless options[:skip_instruct]
+    write_xml(xml)
+  end
+
   module ClassMethods
     def write_xml(msgs)
       xml = Builder::XmlMarkup.new(:indent => 1)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -204,7 +204,7 @@ Nuntium::Application.routes.draw do
       post '/' => 'api_custom_attributes#create_or_update', :as => :api_custom_attributes_show
     end
 
-    resources :ao_messages, only: [:create], controller: 'api_ao_messages'
+    resources :ao_messages, only: [:index, :create], controller: 'api_ao_messages'
     resources :applications, controller: 'api_applications'
     resources :accounts, controller: 'api_accounts'
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -204,7 +204,7 @@ Nuntium::Application.routes.draw do
       post '/' => 'api_custom_attributes#create_or_update', :as => :api_custom_attributes_show
     end
 
-    resources :ao_messages, only: [:index, :create], controller: 'api_ao_messages'
+    resources :ao_messages, only: [:index, :create], controller: 'api_ao_messages', as: 'api_ao_messages'
     resources :applications, controller: 'api_applications'
     resources :accounts, controller: 'api_accounts'
   end

--- a/test/functional/api_ao_messages_controller_test.rb
+++ b/test/functional/api_ao_messages_controller_test.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+
+class ApiAoMessagesControllerTest < ActionController::TestCase
+  def setup
+    @account = Account.make :password => 'secret'
+    @application = Application.make :account => @account, :password => 'secret'
+  end
+
+  def authorize
+    @request.env['HTTP_AUTHORIZATION'] = http_auth("#{@account.name}/#{@application.name}", 'secret')
+  end
+
+  def create_test_ao_messages(token)
+    @ao_msg1 = AoMessage.create! :account_id => @account.id, :application_id => @application.id, :state => 'pending', :body => 'one', :to => 'sms://1', token: token
+    @ao_msg2 = AoMessage.create! :account_id => @account.id, :application_id => @application.id, :state => 'pending', :body => 'one', :to => 'sms://1', token: token
+    @ao_msg3 = AoMessage.create! :account_id => @account.id, :application_id => @application.id, :state => 'pending', :body => 'two', :to => 'sms://1'
+  end
+
+  test "index" do
+    create_test_ao_messages(token = Guid.new.to_s)
+    authorize
+    get :index, format: "json", token: token
+    assert_response :ok
+
+    assert_equal [
+      {
+        "to" => "sms://1",
+        "body" => "one",
+        "guid" => @ao_msg1.guid,
+        "channel" => nil,
+        "channel_kind" => nil,
+        "state" => "pending"
+      },
+      {
+        "to" => "sms://1",
+        "body" => "one",
+        "guid" => @ao_msg2.guid,
+        "channel" => nil,
+        "channel_kind" => nil,
+        "state" => "pending"
+      }
+    ], JSON.parse(@response.body)
+  end
+
+  test "index requires the token param" do
+    authorize
+    get :index, format: "json"
+    assert_response :bad_request
+  end
+end

--- a/test/functional/api_ao_messages_controller_test.rb
+++ b/test/functional/api_ao_messages_controller_test.rb
@@ -80,7 +80,7 @@ class ApiAoMessagesControllerTest < ActionController::TestCase
 
     get :index, format: "json", token: token
     assert_response :ok
-    assert_equal %(<#{api_ao_messages_url(page: 2)}>; rel="next"), response.headers["Link"]
+    assert_equal %(<#{api_ao_messages_url(token: token, page: 2)}>; rel="next"), response.headers["Link"]
     assert_equal 50, JSON.parse(@response.body).size
 
     get :index, format: "json", token: token, page: 2

--- a/test/functional/api_ao_messages_controller_test.rb
+++ b/test/functional/api_ao_messages_controller_test.rb
@@ -16,7 +16,7 @@ class ApiAoMessagesControllerTest < ActionController::TestCase
     @ao_msg3 = AoMessage.create! :account_id => @account.id, :application_id => @application.id, :state => 'pending', :body => 'two', :to => 'sms://1'
   end
 
-  test "index" do
+  test "index as json" do
     create_test_ao_messages(token = Guid.new.to_s)
     authorize
     get :index, format: "json", token: token
@@ -40,6 +40,30 @@ class ApiAoMessagesControllerTest < ActionController::TestCase
         "state" => "pending"
       }
     ], JSON.parse(@response.body)
+  end
+
+  test "index as xml" do
+    create_test_ao_messages(token = Guid.new.to_s)
+    authorize
+    get :index, format: "xml", token: token
+    assert_response :ok
+
+    assert_equal [
+      {
+        "from" => "",
+        "id" => @ao_msg1.guid,
+        "property" => { "name" => "token", "value" => token },
+        "text" => "one",
+        "to" => "sms://1"
+      },
+      {
+        "from" => "",
+        "id" => @ao_msg2.guid,
+        "property" => { "name" => "token", "value" => token },
+        "text" => "one",
+        "to" => "sms://1"
+      }
+    ], Hash.from_xml(@response.body)["ao_messages"]["message"]
   end
 
   test "index requires the token param" do


### PR DESCRIPTION
Exposes the `ao_messages#get_ao` to the OAuth 2.0 API.
Requires the `token` attribute to be defined.