### PR TITLE
Fix assets pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ RUN printf "\ndeb [trusted=yes] http://archive.debian.org/debian jessie-backport
 # Cleanup expired Let's Encrypt CA (Sept 30, 2021)
 RUN sed -i '/^mozilla\/DST_Root_CA_X3/s/^/!/' /etc/ca-certificates.conf && update-ca-certificates -f
 
-# Install nodejs (ignoring GPG's signature expiration, since Debian Jessie won't get those updated: https://wiki.debian.org/DebianJessie )
 RUN apt-get update && \
+  curl -sL https://deb.nodesource.com/setup_4.x | bash - && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes nodejs && \
   # I wasn't able to pin-point which packages need to be updated in order for Let's Encrypt new Root CA to work
   # Upgrading every available package does the trick - so we'll go with that, even at the cost of a larger Docker image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM ruby:1.9
+FROM instedd/ruby:1.9 AS dev
 
-# ruby:1.9 is based on Debian Jessie, which has been archived now
-# we also need jessie-backports to support the new Let's Encrypt Root CA
-RUN printf "deb http://archive.debian.org/debian jessie main\ndeb http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list
+# we need jessie-backports to support the new Let's Encrypt Root CA
+RUN printf "\ndeb [trusted=yes] http://archive.debian.org/debian jessie-backports main" >> /etc/apt/sources.list
 
 # Cleanup expired Let's Encrypt CA (Sept 30, 2021)
 RUN sed -i '/^mozilla\/DST_Root_CA_X3/s/^/!/' /etc/ca-certificates.conf && update-ca-certificates -f
@@ -12,16 +11,19 @@ RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes nodejs && \
   # I wasn't able to pin-point which packages need to be updated in order for Let's Encrypt new Root CA to work
   # Upgrading every available package does the trick - so we'll go with that, even at the cost of a larger Docker image
-  DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --force-yes && \
+  DEBIAN_FRONTEND=noninteractive apt-get upgrade && \
   apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Update gem version to one that's compatible with Let's Encrypt new Root CA
 RUN gem update --system 1.8.30
 
+WORKDIR /app
+
+FROM dev AS release
+
 # Install gem bundle
 ADD Gemfile /app/
 ADD Gemfile.lock /app/
-WORKDIR /app
 RUN bundle install --jobs 3 --deployment --without development test
 
 # Install the application

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - db:/var/lib/mysql
 
   rabbitmq:
-    image: rabbitmq:3.5.3
+    image: rabbitmq:3
     hostname: nuntium_rabbitmq
     volumes:
       - rabbitmq:/var/lib/rabbitmq
@@ -21,7 +21,7 @@ services:
       RABBITMQ_DEFAULT_VHOST: /nuntium/development
 
   memcached:
-    image: memcached:1.4.24
+    image: memcached:1.4.39
 
   web: &rails
     image: instedd/nginx-rails:1.9

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,11 @@ services:
     image: memcached:1.4.39
 
   web: &rails
-    image: instedd/nginx-rails:1.9
+    platform: linux/amd64
+    build:
+      context: ./
+      dockerfile: Dockerfile
+      target: dev
     environment:
       RAILS_ENV:
       DATABASE_HOST: 'db'


### PR DESCRIPTION
Something changed in the Docker images that made them include a buggy version of NodeJS:

```
root@e8e8b05911d5:/app# nodejs --version
Error: unrecognized flag --no-opt
Try --help for options

module.js:340
    throw err;
          ^
Error: Cannot find module 'process'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/proc/.reset:1:71)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
```

That in turn prevented the asset pipeline from working.

There were also issues with the format version of some images.

This PR fixes all of that so we can build & run Nuntium in new Docker versions.