### PR TITLE
Add channel relative ID for iTexmo ATs

### DIFF
--- a/app/controllers/itexmo_controller.rb
+++ b/app/controllers/itexmo_controller.rb
@@ -30,7 +30,7 @@ class ItexmoController < ApplicationController
     to = params["gateway"]
 
     unknown_params = params.except(
-      'originator', 'gateway', 'message', 'timestamp', # iTexmo API specification
+      'originator', 'gateway', 'message', 'timestamp', 'reference_id', # iTexmo API specification
       'account_name', 'channel_name', 'incoming_password', 'controller', 'action' # Rails-generated parameters
     )
 
@@ -38,6 +38,7 @@ class ItexmoController < ApplicationController
     msg.from = "sms://#{from}"
     msg.to = "sms://#{to}"
     msg.body = params["message"]
+    msg.channel_relative_id = params["reference_id"]
 
     account.route_at msg, channel
 


### PR DESCRIPTION
iTexmo Support confirmed via email that they send this `reference_id` - though we don't know for sure if it's an identifier or not.