### PR TITLE
iTexmo: new send SMS base URL

### DIFF
--- a/app/controllers/itexmo_controller.rb
+++ b/app/controllers/itexmo_controller.rb
@@ -30,7 +30,7 @@ class ItexmoController < ApplicationController
     to = params["gateway"]
 
     unknown_params = params.except(
-      'originator', 'gateway', 'message', 'timestamp', # iTexmo API specification
+      'originator', 'gateway', 'message', 'timestamp', 'reference_id', # iTexmo API specification
       'account_name', 'channel_name', 'incoming_password', 'controller', 'action' # Rails-generated parameters
     )
 
@@ -38,6 +38,7 @@ class ItexmoController < ApplicationController
     msg.from = "sms://#{from}"
     msg.to = "sms://#{to}"
     msg.body = params["message"]
+    msg.channel_relative_id = params["reference_id"]
 
     account.route_at msg, channel
 

--- a/app/controllers/itexmo_controller.rb
+++ b/app/controllers/itexmo_controller.rb
@@ -61,6 +61,8 @@ class ItexmoController < ApplicationController
       ao_message.state = 'delivered' if ['queued', 'pending'].include?(ao_message.state)
     when 'delivered'
       ao_message.state = 'confirmed'
+    when 'rejected'
+      ao_message.state = 'failed'
     else
       channel.logger.warning :channel_id => channel.id, :ao_message_id => ao_message.id, :message => "Received unknown-status delivery notification for AO #{ao_message.id}: #{params.to_json}"
     end
@@ -68,6 +70,7 @@ class ItexmoController < ApplicationController
     ao_message.custom_attributes["itexmo_network_submit_time"] = params['NetworkSubmitTime'] if params['NetworkSubmitTime']
     ao_message.custom_attributes["itexmo_client_submit_time"] = params['ClientSubmitTime'] if params['ClientSubmitTime']
     ao_message.custom_attributes["itexmo_done_time"] = params['DoneTime'] if params['DoneTime']
+    ao_message.custom_attributes["itexmo_recipient_network"] = params['RecipientNetwork'] if params['RecipientNetwork']
     ao_message.channel_relative_id ||= params['LongID']
 
     ao_message.save!

--- a/app/controllers/itexmo_controller.rb
+++ b/app/controllers/itexmo_controller.rb
@@ -57,7 +57,7 @@ class ItexmoController < ApplicationController
     ao_message = channel.ao_messages.find_by_id(params[:ao_message_id])
 
     case params['Status'].try :downcase
-    when 'accepted'
+    when 'accepted', 'sent'
       ao_message.state = 'delivered' if ['queued', 'pending'].include?(ao_message.state)
     when 'delivered'
       ao_message.state = 'confirmed'

--- a/app/models/itexmo/itexmo.rb
+++ b/app/models/itexmo/itexmo.rb
@@ -17,7 +17,7 @@
 
 class Itexmo
   # endpoint shared internally by iTexmo
-  SMS_SEND_URL = 'https://api.itexmo.com/api/broadcast/access-code'
+  SMS_SEND_URL = 'https://api.itexmo.com/api/broadcast'
 
   def self.send_message_parameters(params)
     {


### PR DESCRIPTION
We're having issues with sending SMS through iTexmo in the Philippines with a Sender ID.

Here we change the base URL for sending SMS, since that's the only difference we found in the new docs shared by iTexmo support.