### PR TITLE
added custom sms_send_url for itexmo channels

### DIFF
--- a/app/models/itexmo/itexmo_channel.rb
+++ b/app/models/itexmo/itexmo_channel.rb
@@ -18,7 +18,7 @@
 class ItexmoChannel < Channel
   include GenericChannel
 
-  configuration_accessor :email, :api_code, :incoming_password, :api_password, :sender_id
+  configuration_accessor :email, :api_code, :incoming_password, :api_password, :sender_id, :sms_send_url
   validates_presence_of :email, :api_code, :incoming_password, :api_password, :sender_id
   before_validation :generate_incoming_password
   handle_password_change :api_code

--- a/app/models/itexmo/send_itexmo_message_job.rb
+++ b/app/models/itexmo/send_itexmo_message_job.rb
@@ -27,8 +27,10 @@ class SendItexmoMessageJob < SendMessageJob
       delivery_report_url: NamedRoutes.itexmo_delivery_url(@account.name, @channel.name, @config[:incoming_password], @msg.id)
     })
 
+    target_url = @config[:sms_send_url].present? ? @config[:sms_send_url] : Itexmo::SMS_SEND_URL
+
     begin
-      raw_response = RestClient::Request.execute(:method => :post, :url => Itexmo::SMS_SEND_URL, :payload => query_parameters, :timeout => 30)
+      raw_response = RestClient::Request.execute(:method => :post, :url => target_url, :payload => query_parameters, :timeout => 30)
 
       response = JSON.parse raw_response
 

--- a/app/views/channels/_form_itexmo.html.erb
+++ b/app/views/channels/_form_itexmo.html.erb
@@ -22,6 +22,10 @@
     <%= f.text_field :incoming_password, :autocomplete => :off, :maxlength => 32 -%>
     <input type="button" onClick="regenerate_token()" value="Regenerate Password" />
   </p>
+  <p>
+    <%= f.label :sms_send_url, "SMS Send URL" %><br />
+    <%= f.text_field :sms_send_url, title: "Leave blank to use the default Itexmo API endpoint" %>
+  </p>
   <%= render 'edit_footer', :f => f %>
 <%- end -%>
 


### PR DESCRIPTION
Itexmo has different endpoints for sending SMSs, since we started using 2 channels, one a Sender ID and the other access code, we've experienced some failures that were misteriously fixed by using different endpoints for each. 
This small changes gives the user the possibility of defining custom urls for sending messages.